### PR TITLE
feat(openclaw): add custom OpenClaw image with system packages

### DIFF
--- a/apps/openclaw/Dockerfile
+++ b/apps/openclaw/Dockerfile
@@ -1,0 +1,18 @@
+ARG VERSION=latest
+
+FROM ghcr.io/openclaw/openclaw:${VERSION}
+
+USER root
+
+# System packages missing from the upstream image
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+      ca-certificates \
+      unzip \
+      jq \
+      python3 \
+      golang-go \
+      openssh-client \
+    && rm -rf /var/lib/apt/lists/*
+
+USER node

--- a/apps/openclaw/docker-bake.hcl
+++ b/apps/openclaw/docker-bake.hcl
@@ -1,0 +1,41 @@
+target "docker-metadata-action" {}
+
+variable "APP" {
+  default = "openclaw"
+}
+
+variable "VERSION" {
+  // renovate: datasource=docker depName=ghcr.io/openclaw/openclaw
+  default = "2026.4.10"
+}
+
+variable "SOURCE" {
+  default = "https://github.com/openclaw/openclaw"
+}
+
+group "default" {
+  targets = ["image-local"]
+}
+
+target "image" {
+  inherits = ["docker-metadata-action"]
+  args = {
+    VERSION = "${VERSION}"
+  }
+  labels = {
+    "org.opencontainers.image.source" = "${SOURCE}"
+  }
+}
+
+target "image-local" {
+  inherits = ["image"]
+  output = ["type=docker"]
+  tags = ["${APP}:${VERSION}"]
+}
+
+target "image-all" {
+  inherits = ["image"]
+  platforms = [
+    "linux/amd64"
+  ]
+}

--- a/apps/openclaw/tests.yaml
+++ b/apps/openclaw/tests.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/goss-org/goss/master/docs/schema.yaml
+process:
+  node:
+    running: true
+port:
+  tcp:18789:
+    listening: true
+http:
+  http://localhost:18789/healthz:
+    status: 200
+command:
+  gh:
+    exit-status: 1
+    exec: "which jq"
+  python3:
+    exit-status: 0
+    exec: "python3 --version"
+  go:
+    exit-status: 0
+    exec: "go version"

--- a/apps/openclaw/tests.yaml
+++ b/apps/openclaw/tests.yaml
@@ -1,21 +1,30 @@
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/goss-org/goss/master/docs/schema.yaml
-process:
-  node:
-    running: true
-port:
-  tcp:18789:
-    listening: true
-http:
-  http://localhost:18789/healthz:
-    status: 200
 command:
-  gh:
-    exit-status: 1
-    exec: "which jq"
-  python3:
+  jq-installed:
+    exit-status: 0
+    exec: "jq --version"
+  python3-installed:
     exit-status: 0
     exec: "python3 --version"
-  go:
+  go-installed:
     exit-status: 0
     exec: "go version"
+  git-installed:
+    exit-status: 0
+    exec: "git --version"
+  curl-installed:
+    exit-status: 0
+    exec: "curl --version"
+  ssh-installed:
+    exit-status: 0
+    exec: "ssh -V"
+  unzip-installed:
+    exit-status: 0
+    exec: "which unzip"
+  node-installed:
+    exit-status: 0
+    exec: "node --version"
+  openclaw-binary:
+    exit-status: 0
+    exec: "openclaw --version"


### PR DESCRIPTION
Adds a custom OpenClaw container image based on upstream `ghcr.io/openclaw/openclaw`.

## Packages added
- `ca-certificates` — fixes TLS/HTTPS for curl and tools
- `unzip` — for extracting zip-distributed binaries
- `jq` — JSON processing
- `python3` — scripting
- `golang-go` — for Go-based tools
- `openssh-client` — for SSH/SCP access

## Why
The upstream OpenClaw image is minimal. Running in a read-only K8s container, many tools need system-level dependencies that cannot be installed at runtime.

## Versioning
Renovate tracks `ghcr.io/openclaw/openclaw` via the `docker-bake.hcl` version variable. Pushes to `ghcr.io/fastlorenzo/openclaw`.