### PR TITLE
fix(kopia): add sleep.sh init script required by kopia-operator

### DIFF
--- a/apps/kopia/Dockerfile
+++ b/apps/kopia/Dockerfile
@@ -29,4 +29,7 @@ RUN \
     && chmod +x /bin/kopia \
     && rm -rf /tmp/*
 
+COPY scripts/ /scripts/
+RUN chmod +x /scripts/*.sh
+
 CMD ["kopia"]

--- a/apps/kopia/scripts/sleep.sh
+++ b/apps/kopia/scripts/sleep.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# sleep.sh — init container wait script for kopia-operator
+# Usage: sleep.sh <interval_seconds> <max_retries>
+# Sleeps for the given interval, up to max_retries times.
+# Used as an init container to add a brief delay before the snapshot runs.
+
+INTERVAL="${1:-1}"
+MAX_RETRIES="${2:-10}"
+
+echo "Waiting ${INTERVAL}s x ${MAX_RETRIES} before starting..."
+for i in $(seq 1 "$MAX_RETRIES"); do
+  sleep "$INTERVAL"
+done
+echo "Wait complete, proceeding."

--- a/apps/kopia/tests.yaml
+++ b/apps/kopia/tests.yaml
@@ -2,5 +2,8 @@
 schemaVersion: "2.0.0"
 fileExistenceTests:
   - name: kopia
-    path: /usr/bin/kopia
+    path: /bin/kopia
+    shouldExist: true
+  - name: sleep-script
+    path: /scripts/sleep.sh
     shouldExist: true


### PR DESCRIPTION
## Problem

All snapshot CronJob pods fail with `RunContainerError` because the init container tries to run `/scripts/sleep.sh` which doesn't exist in the image.

```
Command: /scripts/sleep.sh
Args: 1, 10
```

This script was present in older image versions (0.16.x) but was lost during Dockerfile updates.

## Fix

Add back the `/scripts/sleep.sh` script. It's a simple wait loop used by the kopia-operator init container to add a brief delay before snapshots run.

## Impact

Unblocks all snapshot CronJobs on both k8s-home and k8s-infra clusters.