### PR TITLE
fix(alerta-web): ship webhook/ in the build context + plugin hardening

### DIFF
--- a/apps/alerta-web/.dockerignore
+++ b/apps/alerta-web/.dockerignore
@@ -1,0 +1,9 @@
+# App-local override of include/.dockerignore (which the app-builder
+# workflow rsyncs into this directory with --ignore-existing, so this file
+# wins): same rules, plus the webhook/ plugin sources that the Dockerfile
+# COPYs into the image.
+/*
+!defaults/
+!scripts/
+!entrypoint.sh
+!webhook/

--- a/apps/alerta-web/docker-bake.hcl
+++ b/apps/alerta-web/docker-bake.hcl
@@ -1,7 +1,7 @@
 target "docker-metadata-action" {}
 
 variable "APP" {
-  default = "openclaw"
+  default = "alerta-web"
 }
 
 variable "VERSION" {

--- a/apps/alerta-web/tests.yaml
+++ b/apps/alerta-web/tests.yaml
@@ -5,3 +5,8 @@ fileExistenceTests:
   - name: alerta
     path: /venv/bin/alerta
     shouldExist: true
+commandTests:
+  - name: cluster webhook plugin importable
+    command: /venv/bin/python
+    args: ["-c", "import alerta_prometheus_cluster"]
+    exitCode: 0

--- a/apps/alerta-web/webhook/alerta_prometheus_cluster.py
+++ b/apps/alerta-web/webhook/alerta_prometheus_cluster.py
@@ -47,15 +47,15 @@ class PrometheusClusterWebhook(WebhookBase):
                     400,
                 )
 
+            # Alertmanager groups several alerts into one notification; a 400
+            # here would reject the whole batch (and dead-man style alerts
+            # built on absent()/vector(1) legitimately carry no cluster
+            # label). When the label is missing, inject nothing and let
+            # parse_prometheus fall back to DEFAULT_ENVIRONMENT.
             cluster = labels.get("cluster")
-            if not isinstance(cluster, str) or not cluster.strip():
-                raise ApiError(
-                    'Prometheus alert is missing required label "cluster"',
-                    400,
-                )
-
-            # Let the standard Alerta Prometheus parser handle everything else.
-            labels["environment"] = cluster.strip()
+            if isinstance(cluster, str) and cluster.strip():
+                # Let the standard Alerta Prometheus parser handle the rest.
+                labels["environment"] = cluster.strip()
 
             parsed_alerts.append(
                 parse_prometheus(transformed_alert, external_url)


### PR DESCRIPTION
## Root cause of the failing build ([run 29363313955](https://github.com/fastlorenzo/containers/actions/runs/29363313955))

`COPY ./webhook` failed with `"/webhook": not found` and the context transferred **2 bytes** (empty). The app-builder workflow rsyncs `include/` into the app directory before bake, and `include/.dockerignore` excludes everything from the context except `defaults/`, `scripts/` and `entrypoint.sh` — so `webhook/` never reached the builder. The rsync uses `--ignore-existing`, so an **app-local `.dockerignore` wins** (same escape hatch as `apps/zguard`).

## Changes

- **`apps/alerta-web/.dockerignore`** (new, the actual fix): include-dir rules + `!webhook/`
- **webhook plugin robustness**: a missing `cluster` label no longer raises 400 — Alertmanager groups several alerts per notification, so one label-less alert (e.g. dead-man expressions built on `absent()`/`vector(1)`) would poison the whole batch. It now falls back to `DEFAULT_ENVIRONMENT` (Production) instead. Structural validation (non-dict alert, missing labels) still 400s.
- **`docker-bake.hcl`**: `APP` default was a copy-paste leftover (`openclaw`) → `alerta-web`
- **`tests.yaml`**: container-structure-test asserting `import alerta_prometheus_cluster` works, so a broken plugin install fails CI instead of the cluster

## Review of the plugin approach (verified against Alerta v9.1.0 source)

The design is correct: stock `parse_prometheus` does `environment = labels.pop('environment', DEFAULT_ENVIRONMENT)`, so injecting `labels['environment'] = cluster` and delegating works as intended. The entry point (group `alerta.webhooks`, name `prometheus-cluster`) is auto-discovered → endpoint **`/api/webhooks/prometheus-cluster`**.

⚠️ Follow-up in k8s-infra after this merges + releases: point the Alertmanager Alerta receiver at `/api/webhooks/prometheus-cluster` (it currently posts to the stock `/api/webhooks/prometheus`, which ignores the plugin) and switch the helmrelease image to `ghcr.io/fastlorenzo/alerta-web`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)