### PR TITLE
fix(alerta-web): normalize Prometheus severities for the Alerta alarm model

### DIFF
--- a/apps/alerta-web/webhook/alerta_prometheus_cluster.py
+++ b/apps/alerta-web/webhook/alerta_prometheus_cluster.py
@@ -7,10 +7,27 @@ from alerta.webhooks import WebhookBase
 from alerta.webhooks.prometheus import parse_prometheus
 
 
+# Alerta's default alarm model hard-rejects severities outside its fixed
+# set (alerta/models/alarms/alerta.py raises ApiError, which surfaces as a
+# 500 and fails the WHOLE grouped Alertmanager notification). Prometheus
+# rules commonly use the critical/error/warning/info convention, so map the
+# two names Alerta doesn't know and coerce anything else unrecognized to
+# "indeterminate" instead of letting one alert poison the batch.
+VALID_SEVERITIES = {
+    "security", "critical", "major", "minor", "warning", "indeterminate",
+    "informational", "normal", "ok", "cleared", "debug", "trace", "unknown",
+}
+SEVERITY_MAP = {
+    "error": "major",
+    "info": "informational",
+}
+
+
 class PrometheusClusterWebhook(WebhookBase):
     """
     Prometheus Alertmanager webhook that maps the Prometheus `cluster`
-    label to the Alerta `environment` field.
+    label to the Alerta `environment` field and normalizes Prometheus
+    severity names to Alerta's alarm model.
     """
 
     def incoming(
@@ -56,6 +73,15 @@ class PrometheusClusterWebhook(WebhookBase):
             if isinstance(cluster, str) and cluster.strip():
                 # Let the standard Alerta Prometheus parser handle the rest.
                 labels["environment"] = cluster.strip()
+
+            severity = labels.get("severity")
+            if isinstance(severity, str):
+                severity = severity.strip().lower()
+                labels["severity"] = SEVERITY_MAP.get(
+                    severity,
+                    severity if severity in VALID_SEVERITIES
+                    else "indeterminate",
+                )
 
             parsed_alerts.append(
                 parse_prometheus(transformed_alert, external_url)

--- a/apps/alerta-web/webhook/setup.py
+++ b/apps/alerta-web/webhook/setup.py
@@ -3,8 +3,11 @@ from setuptools import setup
 
 setup(
     name="alerta-prometheus-cluster-webhook",
-    version="0.1.0",
-    description="Map Prometheus cluster labels to Alerta environments",
+    version="0.2.0",
+    description=(
+        "Map Prometheus cluster labels to Alerta environments and "
+        "normalize Prometheus severities to Alerta's alarm model"
+    ),
     py_modules=["alerta_prometheus_cluster"],
     install_requires=[],
     entry_points={


### PR DESCRIPTION
Found during live verification of #2780: the cluster→environment webhook now works (alerts land as `k8s-infra`/`k8s-home` ✅), but **38 of the first 73 grouped notifications returned 500**.

## Root cause

Alerta's alarm model hard-rejects severities outside its fixed set (`security, critical, major, minor, warning, indeterminate, informational, normal, ok, cleared, debug, trace, unknown`). Our Prometheus rules use the common `error` / `info` convention — and because Alertmanager groups several alerts per notification, **one invalid severity fails the entire batch** with a 500:

```
alerta.exceptions.ApiError: Severity (info) is not one of security, critical, major, ...
```

## Fix

Normalize in the same custom webhook, before delegating to the stock parser:

| Prometheus | Alerta |
|---|---|
| `error` | `major` |
| `info` | `informational` |
| anything else unrecognized | `indeterminate` |
| already-valid values | passthrough (lowercased) |

Plugin bumped to 0.2.0.

After merge + release I'll bump the image digest in k8s-infra and re-verify (the tag stays `9.1.0`, so the digest pin must move).

🤖 Generated with [Claude Code](https://claude.com/claude-code)