### PR TITLE
fix(holmes-poller): forbid unattended Holmes from asking for confirmation

### DIFF
--- a/apps/holmes-poller/docker-bake.hcl
+++ b/apps/holmes-poller/docker-bake.hcl
@@ -5,7 +5,7 @@ variable "APP" {
 }
 
 variable "VERSION" {
-  default = "0.1.0"
+  default = "0.1.1"
 }
 
 variable "SOURCE" {

--- a/apps/holmes-poller/src/poller.py
+++ b/apps/holmes-poller/src/poller.py
@@ -248,6 +248,11 @@ def build_prompt(env: str, incident_id: str, members: list[dict], other_alerts: 
         "chart/image version change as a suspect.",
         "(d) Propose concrete remediation steps for a human operator. You cannot make changes "
         "yourself -- writes happen only via Git PRs.",
+        "",
+        "You are running unattended: nobody can answer questions or confirm anything. Never "
+        "end with a question or a request for confirmation. If a tool call fails, try a "
+        "different approach; if data is unavailable, state the assumption you made and give "
+        "your best conclusion from the evidence you have.",
     ]
 
     if other_alerts:


### PR DESCRIPTION
The first real incident through the pipeline (NodeDiskIOSaturation on k8s-infra, 2026-07-15 05:26Z) produced an RCA note that ended with a request for confirmation after a kubectl syntax error - a dead end in an unattended flow. This adds a prompt instruction: never ask questions, retry with different approaches, state assumptions, always conclude. VERSION 0.1.0 -> 0.1.1; the k8s-infra digest bump follows after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)