### PR TITLE
feat(xigmanas-backup): support object-lock-enabled buckets

### DIFF
--- a/apps/xigmanas-backup/README.md
+++ b/apps/xigmanas-backup/README.md
@@ -33,6 +33,8 @@ file (takes precedence over the plain variable).
 | `S3_SECRET_ACCESS_KEY` / `_FILE` | yes¹ | — | Secret key |
 | `S3_PREFIX` | no | `xigmanas/` | Key prefix (normalized to end with `/`) |
 | `S3_REGION` | no | — | Region, if the endpoint needs one |
+| `OBJECT_LOCK_MODE` | no | — | `GOVERNANCE` or `COMPLIANCE`: apply per-object lock retention on upload |
+| `OBJECT_LOCK_RETAIN_DAYS` | no | — | Lock duration in days; required together with `OBJECT_LOCK_MODE` |
 | `RETENTION_COUNT` | no | `8` | Newest N backups to keep; `0` disables pruning |
 | `TLS_VERIFY` | no | `true` | `false` disables NAS certificate verification (warning logged) |
 | `CA_BUNDLE` | no | — | Path to a mounted PEM bundle for the NAS certificate |
@@ -44,6 +46,22 @@ file (takes precedence over the plain variable).
 
 Pruning only ever touches keys matching `<prefix>config-*-YYYYmmddHHMMSS.gz`;
 anything else under the prefix is left alone.
+
+## Object lock / immutable buckets
+
+Uploads always send `Content-MD5`, so buckets with S3 Object Lock enabled work
+out of the box. Note that enabling lock on a bucket does **not** make new
+objects immutable by itself — either configure a *default retention policy* on
+the bucket, or set `OBJECT_LOCK_MODE` + `OBJECT_LOCK_RETAIN_DAYS` so this job
+applies per-object retention at upload (skip these if the bucket already has a
+default policy).
+
+Pruning cannot delete objects still under retention: those are logged as
+warnings, the run still succeeds, and they are pruned by a later run once the
+lock expires. With weekly backups and `RETENTION_COUNT=8`, the object being
+pruned is ~8 weeks old, so a lock duration of ≤49 days keeps count-based
+pruning timely; longer durations just delay pruning (the bucket temporarily
+holds more than N backups).
 
 ## Exit codes
 

--- a/apps/xigmanas-backup/docker-bake.hcl
+++ b/apps/xigmanas-backup/docker-bake.hcl
@@ -5,7 +5,7 @@ variable "APP" {
 }
 
 variable "VERSION" {
-  default = "0.1.0"
+  default = "0.2.0"
 }
 
 variable "SOURCE" {

--- a/apps/xigmanas-backup/scripts/xigmanas_backup.py
+++ b/apps/xigmanas-backup/scripts/xigmanas_backup.py
@@ -22,7 +22,7 @@ import re
 import sys
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from urllib.parse import urlparse
 
 EXIT_OK = 0
@@ -103,6 +103,8 @@ class Config:
     s3_secret_access_key: str | None
     s3_prefix: str
     s3_region: str | None
+    object_lock_mode: str | None
+    object_lock_retain_days: int | None
     retention_count: int
     tls_verify: bool
     ca_bundle: str | None
@@ -151,6 +153,29 @@ def load_config() -> Config:
     if prefix and not prefix.endswith("/"):
         prefix += "/"
 
+    object_lock_mode = get("OBJECT_LOCK_MODE")
+    if object_lock_mode:
+        object_lock_mode = object_lock_mode.upper()
+        if object_lock_mode not in ("GOVERNANCE", "COMPLIANCE"):
+            errors.append(
+                f"OBJECT_LOCK_MODE must be GOVERNANCE or COMPLIANCE, got {object_lock_mode!r}"
+            )
+    object_lock_retain_days: int | None = None
+    raw_lock_days = os.environ.get("OBJECT_LOCK_RETAIN_DAYS")
+    if raw_lock_days:
+        try:
+            object_lock_retain_days = int(raw_lock_days)
+            if object_lock_retain_days <= 0:
+                raise ValueError
+        except ValueError:
+            errors.append(
+                f"OBJECT_LOCK_RETAIN_DAYS must be a positive integer, got {raw_lock_days!r}"
+            )
+    if bool(object_lock_mode) != bool(object_lock_retain_days):
+        errors.append(
+            "OBJECT_LOCK_MODE and OBJECT_LOCK_RETAIN_DAYS must be set together"
+        )
+
     retention_count = 8
     raw_retention = os.environ.get("RETENTION_COUNT", "8")
     try:
@@ -193,6 +218,8 @@ def load_config() -> Config:
         s3_secret_access_key=s3_secret_access_key,
         s3_prefix=prefix,
         s3_region=get("S3_REGION"),
+        object_lock_mode=object_lock_mode,
+        object_lock_retain_days=object_lock_retain_days,
         retention_count=retention_count,
         tls_verify=tls_verify,
         ca_bundle=ca_bundle,
@@ -361,20 +388,34 @@ def make_s3(cfg: Config):
             retries={"max_attempts": 3, "mode": "standard"},
             connect_timeout=10,
             read_timeout=60,
+            # S3-compatible endpoints may reject AWS's newer default
+            # checksums; integrity is covered by the explicit Content-MD5.
+            request_checksum_calculation="when_required",
+            response_checksum_validation="when_required",
         ),
     )
 
 
 def upload(s3, cfg: Config, blob: bytes, key: str) -> str:
     digest = hashlib.sha256(blob).hexdigest()
-    try:
-        s3.put_object(
-            Bucket=cfg.s3_bucket,
-            Key=key,
-            Body=blob,
-            ContentType="application/octet-stream",
-            Metadata={"sha256": digest},
+    kwargs = {
+        "Bucket": cfg.s3_bucket,
+        "Key": key,
+        "Body": blob,
+        "ContentType": "application/octet-stream",
+        # Object-lock-enabled buckets require Content-MD5 on PUT.
+        "ContentMD5": base64.b64encode(hashlib.md5(blob).digest()).decode(),
+        "Metadata": {"sha256": digest},
+    }
+    if cfg.object_lock_mode:
+        retain_until = datetime.now(timezone.utc) + timedelta(days=cfg.object_lock_retain_days)
+        kwargs["ObjectLockMode"] = cfg.object_lock_mode
+        kwargs["ObjectLockRetainUntilDate"] = retain_until
+        log.info(
+            "applying object lock: %s until %s", cfg.object_lock_mode, retain_until.date()
         )
+    try:
+        s3.put_object(**kwargs)
     except Exception as exc:
         raise UploadError(f"put_object s3://{cfg.s3_bucket}/{key} failed: {exc}") from exc
     log.info("uploaded s3://%s/%s (%d bytes, sha256=%s)", cfg.s3_bucket, key, len(blob), digest)
@@ -399,6 +440,7 @@ def prune(s3, cfg: Config, just_uploaded_key: str) -> tuple[int, int]:
     if cfg.retention_count == 0:
         log.info("RETENTION_COUNT=0: pruning disabled")
         return 0, 0
+    deleted = 0
     try:
         objects = list_backups(s3, cfg)
         stale = [
@@ -406,15 +448,31 @@ def prune(s3, cfg: Config, just_uploaded_key: str) -> tuple[int, int]:
         ]
         for chunk_start in range(0, len(stale), 1000):
             chunk = stale[chunk_start : chunk_start + 1000]
-            s3.delete_objects(
+            resp = s3.delete_objects(
                 Bucket=cfg.s3_bucket,
                 Delete={"Objects": [{"Key": o["Key"]} for o in chunk], "Quiet": True},
             )
+            failed = {e["Key"]: e for e in resp.get("Errors", [])}
             for obj in chunk:
-                log.info("pruned s3://%s/%s (%s)", cfg.s3_bucket, obj["Key"], obj["LastModified"])
+                if obj["Key"] in failed:
+                    err = failed[obj["Key"]]
+                    # Expected on object-lock-enabled buckets while the
+                    # retention period holds; retried on a later run.
+                    log.warning(
+                        "could not prune s3://%s/%s: %s %s (still under object lock?)",
+                        cfg.s3_bucket,
+                        obj["Key"],
+                        err.get("Code"),
+                        err.get("Message"),
+                    )
+                else:
+                    deleted += 1
+                    log.info(
+                        "pruned s3://%s/%s (%s)", cfg.s3_bucket, obj["Key"], obj["LastModified"]
+                    )
     except Exception as exc:
         raise PruneError(f"pruning old backups failed: {exc}") from exc
-    return len(objects) - len(stale), len(stale)
+    return len(objects) - len(stale), deleted
 
 
 def run(cfg: Config) -> int:


### PR DESCRIPTION
Follow-up to #2784 for buckets with S3 Object Lock enabled (0.1.0 → 0.2.0):

- **Uploads** always send `Content-MD5` — required on lock-enabled buckets, harmless otherwise. botocore checksum behavior pinned to `when_required` for S3-compatible endpoints.
- **Per-object retention (optional)**: `OBJECT_LOCK_MODE` (`GOVERNANCE`/`COMPLIANCE`) + `OBJECT_LOCK_RETAIN_DAYS` apply lock retention at upload, for buckets without a default retention policy (enabling lock alone does not make objects immutable).
- **Prune vs. lock**: `delete_objects` per-key errors are now inspected; objects still under retention log a warning and are retried on later runs once the lock expires (previously errors were silently ignored). README documents the retention/`RETENTION_COUNT` interplay.

Tested: rebuild + all container-structure-tests pass; env validation covers mode-without-days and invalid modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
