### PR TITLE
fix(obsidian-bridge): rate-limit retry + paginated knowledge response

### DIFF
--- a/apps/obsidian-bridge/docker-bake.hcl
+++ b/apps/obsidian-bridge/docker-bake.hcl
@@ -5,7 +5,7 @@ variable "APP" {
 }
 
 variable "VERSION" {
-  default = "0.1.0"
+  default = "0.1.1"
 }
 
 variable "SOURCE" {

--- a/apps/obsidian-bridge/docker-bake.hcl
+++ b/apps/obsidian-bridge/docker-bake.hcl
@@ -5,7 +5,7 @@ variable "APP" {
 }
 
 variable "VERSION" {
-  default = "0.1.1"
+  default = "0.1.2"
 }
 
 variable "SOURCE" {

--- a/apps/obsidian-bridge/src/bridge/__init__.py
+++ b/apps/obsidian-bridge/src/bridge/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"

--- a/apps/obsidian-bridge/src/bridge/__init__.py
+++ b/apps/obsidian-bridge/src/bridge/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"

--- a/apps/obsidian-bridge/src/bridge/webui.py
+++ b/apps/obsidian-bridge/src/bridge/webui.py
@@ -111,8 +111,18 @@ class WebUIClient:
     # -- knowledge collections ---------------------------------------------
 
     async def list_knowledge(self) -> list[dict[str, Any]]:
+        """List knowledge collections, tolerating both response shapes.
+
+        v0.10.2 returns {"items": [...]}, older builds a bare list. Silently
+        returning [] for the paginated shape is worse than it sounds: the
+        lookup in ensure_collection would find nothing and create a *second*
+        collection with the same name, and _resolve_kid would fail to find one
+        that plainly exists.
+        """
         response = await self._request("GET", "/api/v1/knowledge/")
         payload = response.json()
+        if isinstance(payload, dict):
+            payload = payload.get("items") or payload.get("data") or []
         return payload if isinstance(payload, list) else []
 
     async def ensure_collection(self, name: str, description: str) -> str:

--- a/apps/obsidian-bridge/src/bridge/webui.py
+++ b/apps/obsidian-bridge/src/bridge/webui.py
@@ -44,12 +44,29 @@ class WebUIClient:
     async def aclose(self) -> None:
         await self._client.aclose()
 
+    @staticmethod
+    def _is_rate_limited(response: httpx.Response) -> bool:
+        """True when the response is a rate limit, however it is dressed up.
+
+        Open WebUI embeds synchronously inside file/add and reports an upstream
+        429 from the gateway as its own **400**, e.g.
+            {"detail": "400: 429, message='Too Many Requests', url='.../embeddings'"}
+        Taking that at face value drops the note as a permanent failure, which
+        is exactly wrong: it is the one error that always deserves a retry.
+        """
+        if response.status_code == 429:
+            return True
+        if response.status_code != 400:
+            return False
+        body = response.text[:500]
+        return "429" in body or "Too Many Requests" in body
+
     async def _request(self, method: str, path: str, **kwargs: Any) -> httpx.Response:
         """Issue a request, retrying only what is worth retrying.
 
-        429 and 5xx are transient (the gateway key is rate limited at rpm 120,
-        and llama-swap may be mid model-swap). 4xx otherwise is a contract
-        problem and retrying just delays the error.
+        Rate limits and 5xx are transient (the gateway key is rate limited, and
+        llama-swap may be mid model-swap). 4xx otherwise is a contract problem
+        and retrying just delays the error.
         """
         delay = 1.0
         last_exc: Exception | None = None
@@ -65,7 +82,7 @@ class WebUIClient:
             else:
                 if response.status_code < 400:
                     return response
-                if response.status_code == 429 or response.status_code >= 500:
+                if self._is_rate_limited(response) or response.status_code >= 500:
                     if attempt == self._max_retries:
                         raise WebUIError(
                             f"{method} {path} -> {response.status_code} after "
@@ -77,7 +94,10 @@ class WebUIClient:
                         "%s %s -> %d, backing off %.1fs", method, path, response.status_code, wait
                     )
                     await asyncio.sleep(wait)
-                    delay = min(delay * 2, 30.0)
+                    # Rate limits are windowed per minute, so back off hard
+                    # enough to actually leave the window rather than nibbling
+                    # at its edge.
+                    delay = min(delay * 2, 60.0)
                     continue
                 raise WebUIError(
                     f"{method} {path} -> {response.status_code}: {response.text[:300]}"


### PR DESCRIPTION
Two bugs found running the bridge against the real vault for the first time.

## 1. Rate limits arriving disguised as 400s

Open WebUI embeds **synchronously** inside `file/add`, and when the gateway rate limits it, it reports the upstream 429 as its own **400**:

```json
{"detail": "400: 429, message='Too Many Requests', url='http://litellm:4000/v1/embeddings'"}
```

Only a literal `429`/`5xx` was retried, so this was classified as permanent and the note was **dropped from the pass** — 32 notes shed on the first run.

Now a `400` whose body carries `429`/`Too Many Requests` is transient; genuine 400s stay fatal. Backoff ceiling raised 30s → 60s, since these limits are windowed per minute and a lower cap just nibbles at the window's edge.

## 2. Paginated knowledge-collection response

v0.10.2 returns `{"items": [...]}` from `GET /api/v1/knowledge/`, not a bare list, so `list_knowledge()` silently returned `[]`.

Worse than an empty result: `ensure_collection` looks up by name before creating, so with no match it would create a **second** "Second Brain" beside the existing one, and `_resolve_kid` (backing MCP search) would report no such collection while it sits there in the UI. It went unnoticed because the id is cached in state after the first run — so the lookup is only reached on a fresh state file, exactly the recovery path where a duplicate hurts most.

## Testing

Unit-tested both: the real 429 payload plus genuine-400/401/503 to confirm nothing else became retryable, and all three response shapes plus an unrecognised one. Image rebuilt, all 4 container-structure-tests pass.

Pairs with fastlorenzo/k8s-home#1244.