### PR TITLE
fix(actions-runner): install Homebrew's developer-tools requirements

### DIFF
--- a/apps/actions-runner/Dockerfile
+++ b/apps/actions-runner/Dockerfile
@@ -10,18 +10,26 @@ ENV HOMEBREW_NO_ANALYTICS=1 \
 
 USER root
 
+# build-essential/procps/file are Homebrew-on-Linux's documented requirements
+# (https://docs.brew.sh/Homebrew-on-Linux#requirements). Bare gcc is not enough:
+# `brew install homeport/tap/dyff` has no prebuilt bottle, so brew compiles it
+# from source and aborts with "No developer tools installed" without make and
+# the C headers. build-essential also pulls in libatomic1, which Node >= 24
+# links against — without it `mise install` dies on `node -v`.
 RUN \
     apt-get -qq update \
     && \
     apt-get -qq install -y --no-install-recommends --no-install-suggests \
         ca-certificates \
+        file \
         jo \
         moreutils \
+        procps \
         wget \
         zstd \
     && \
     case "${TARGETARCH}" in \
-        'amd64') apt-get -qq install -y --no-install-recommends --no-install-suggests gcc ;; \
+        'amd64') apt-get -qq install -y --no-install-recommends --no-install-suggests build-essential ;; \
     esac \
     && \
     curl -fsSL "https://github.com/mikefarah/yq/releases/latest/download/yq_linux_${TARGETARCH}" -o /usr/local/bin/yq \

--- a/apps/actions-runner/Dockerfile
+++ b/apps/actions-runner/Dockerfile
@@ -16,10 +16,15 @@ USER root
 # from source and aborts with "No developer tools installed" without make and
 # the C headers. build-essential also pulls in libatomic1, which Node >= 24
 # links against — without it `mise install` dies on `node -v`.
+#
+# Installed on every arch, not just amd64: an arm64 runner hits the same Node
+# libatomic failure, and gating it made the image's contents arch-dependent for
+# no benefit. Homebrew below stays amd64-only — it does not support ARM Linux.
 RUN \
     apt-get -qq update \
     && \
     apt-get -qq install -y --no-install-recommends --no-install-suggests \
+        build-essential \
         ca-certificates \
         file \
         jo \
@@ -27,10 +32,6 @@ RUN \
         procps \
         wget \
         zstd \
-    && \
-    case "${TARGETARCH}" in \
-        'amd64') apt-get -qq install -y --no-install-recommends --no-install-suggests build-essential ;; \
-    esac \
     && \
     curl -fsSL "https://github.com/mikefarah/yq/releases/latest/download/yq_linux_${TARGETARCH}" -o /usr/local/bin/yq \
         && chmod +x /usr/local/bin/yq \

--- a/apps/actions-runner/tests.yaml
+++ b/apps/actions-runner/tests.yaml
@@ -1,24 +1,39 @@
 ---
+# container-structure-test has no per-architecture conditionals and this image
+# is built for both amd64 and arm64, so every assertion here must hold on both.
+# That rules out hardcoded multiarch library paths (/usr/lib/x86_64-linux-gnu/…)
+# and anything installed only under `case "${TARGETARCH}"` — notably Homebrew,
+# which is amd64-only because it does not support ARM Linux.
 schemaVersion: "2.0.0"
 fileExistenceTests:
   - name: runner binary
     path: /home/runner/run.sh
     shouldExist: true
-  # The whole reason this image exists — see the Dockerfile comment.
-  - name: libatomic
-    path: /usr/lib/x86_64-linux-gnu/libatomic.so.1
-    shouldExist: true
 commandTests:
+  # The reason this image exists: Node >= 24 links against libatomic, which the
+  # upstream runner image lacks. Asked via ldconfig rather than a file path so
+  # it holds on both arches, and because what actually matters is that the
+  # dynamic linker can resolve it.
+  - name: libatomic resolvable
+    command: sh
+    args: ["-c", "/sbin/ldconfig -p | grep -q libatomic.so.1"]
+    exitCode: 0
+  # gcc AND make together are what Homebrew checks for before building a
+  # bottle-less formula from source; missing make is what broke helmrelease-diff.
+  - name: gcc
+    command: gcc
+    args: ["--version"]
+    exitCode: 0
+  - name: make
+    command: make
+    args: ["--version"]
+    exitCode: 0
   - name: gh
     command: gh
     args: ["--version"]
     exitCode: 0
   - name: yq
     command: yq
-    args: ["--version"]
-    exitCode: 0
-  - name: gcc
-    command: gcc
     args: ["--version"]
     exitCode: 0
   - name: jq
@@ -31,9 +46,5 @@ commandTests:
     exitCode: 0
   - name: docker cli
     command: docker
-    args: ["--version"]
-    exitCode: 0
-  - name: brew
-    command: /home/linuxbrew/.linuxbrew/bin/brew
     args: ["--version"]
     exitCode: 0


### PR DESCRIPTION
## Why

`helmrelease-diff` fails on the self-hosted runners:

```
==> Installing dyff from homeport/tap
##[error]No developer tools installed.

Install a system C compiler and the standard development tools for
your Linux distribution. See:
  https://docs.brew.sh/Homebrew-on-Linux#requirements
```

The interesting detail is *which* formula fails. `helm`, `kustomize` and `yq` install fine — they're core formulae with prebuilt bottles, so brew just pours them:

```
==> Downloading https://ghcr.io/v2/homebrew/core/helm/manifests/4.2.3
==> Pouring helm--4.2.3.x86_64_linux.bottle.tar.gz
```

`dyff` comes from `homeport/tap`, which publishes **no bottle**. brew therefore compiles it from source, which needs the full toolchain. The image had bare `gcc` — no `make`, no C headers.

## What

Swap `gcc` for `build-essential`, and add `procps` and `file`. Those are exactly Homebrew-on-Linux's documented requirements.

`build-essential` still pulls in `libatomic1` transitively, so the Node >= 24 / `mise install` fix is unaffected.

## Heads-up: this makes CI green but slow

With this change `dyff` gets **compiled from source on every single job**, because ephemeral runners start clean with no brew cache. `dyff` is Go, so brew will pull the Go toolchain as a build dependency each time — likely minutes added to every `helmrelease-diff` run.

On GitHub-hosted runners this was equally true, just less visible.

The better fix is to bake a prebuilt `dyff` binary into this image the same way `yq` already is, then drop `homeport/tap/dyff` from the `brew install` line in k8s-infra's `helmrelease-diff.yaml`. That removes the tap, the source build and the Go dependency in one go. Happy to do that as a follow-up — it needs a coordinated change in both repos, so I kept it out of this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)