### PR TITLE
ci(hadolint): ignore DL3066

### DIFF
--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,6 +1,11 @@
 ---
 # yaml-language-server: $schema=https://json.schemastore.org/hadolint.json
 ignored:
+  # Images intentionally run as a named user inherited from their base image
+  # (USER apps), which hadolint 2.15 started flagging as DL3066. Enforcing
+  # numeric UIDs here would mean rewriting the USER of every app for an
+  # info-level hint, and would change file-ownership behaviour at runtime.
+  - DL3066
   - DL3018
   - DL3013
   - DL3008


### PR DESCRIPTION
Every pull request in this repo is currently failing CI, including unrelated renovate ones (#2847 mise-tools, codeql, radarr).

**Cause:** hadolint 2.15.1 — pulled in by the mise-tools update — enabled `DL3066` (*Non-numeric user-id may not be resolvable by host system*). The Hadolint job lints **all** `apps/**/Dockerfile`, not just the ones a PR touches, so the 35 pre-existing findings across 23 apps (lidarr, plex, sonarr, openclaw, …) gate everything.

Enforcing numeric UIDs instead would mean rewriting the `USER` of every app for an info-level hint, and would change file-ownership behaviour at runtime — so this follows the existing pattern of ignoring rules that don't match the repo's conventions (DL3018/DL3013/DL3008/DL4006/SC3060).

**Verified** with hadolint 2.15.1 over every `apps/**/Dockerfile`:

| config | findings |
|---|---|
| current | 35 (all DL3066) |
| with this change | 0 |

Merging this unblocks the other open PRs, including #2860.

🤖 Generated with [Claude Code](https://claude.com/claude-code)