### PR TITLE
feat(llama-swap-strix): llama-swap with the Strix Halo q8_0-KV FA patch (#25494)

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -152,5 +152,21 @@
       matchUpdateTypes: ["major"],
       automerge: false,
     },
+    {
+      // llama-swap-strix compiles llama.cpp at a pinned release tag and grafts
+      // the result onto the stock llama-swap image built from THAT SAME
+      // llama.cpp build. Its whole purpose is a one-variable A/B against that
+      // base, so VERSION and BASE_IMAGE have to move together. Renovate would
+      // bump the base image digest on its own and automerge it (digest updates
+      // automerge), leaving a patched llama.cpp grafted onto a different
+      // llama.cpp -- which still builds, still runs, and quietly invalidates
+      // every benchmark taken with it. Updates here are manual, and the app's
+      // README says what to re-run afterwards.
+      //
+      // Kept last: later packageRules override earlier ones.
+      description: ["Manual updates only for llama-swap-strix"],
+      matchFileNames: ["apps/llama-swap-strix/**"],
+      enabled: false,
+    },
   ],
 }

--- a/apps/llama-swap-strix/Dockerfile
+++ b/apps/llama-swap-strix/Dockerfile
@@ -1,0 +1,100 @@
+# syntax=docker/dockerfile:1
+#
+# llama-swap with a patched llama.cpp for Strix Halo (gfx1151) — see README.md.
+#
+# The build stages are a deliberate COPY of ggml-org/llama.cpp's own
+# .devops/vulkan.Dockerfile (same ubuntu base, same package list, same cmake
+# flags) with one addition: everything in patches/ is applied to the checked out
+# release tag first. Matching upstream's flags matters more than tidying them —
+# GGML_BACKEND_DL + GGML_CPU_ALL_VARIANTS decide which artifacts land in /app,
+# and a mismatch would leave a half-swapped set of shared objects behind.
+#
+# The final stage grafts the result onto the llama-swap image that ai-box
+# already runs, replacing only llama-server and the ggml backends. llama-swap
+# itself, the entrypoint, the runtime libraries and every path stay as they
+# were, so an A/B against BASE_IMAGE measures the patches and nothing else.
+#
+# NOTE the Vulkan flash-attention code being patched lives in
+# libggml-vulkan.so, NOT in the llama-server binary. Copying only the binary
+# would produce an image that benchmarks exactly like stock.
+
+ARG UBUNTU_VERSION=26.04
+ARG NODE_VERSION=24
+ARG VERSION
+ARG BASE_IMAGE
+
+# ── Web UI ────────────────────────────────────────────────────────────
+# llama-server embeds tools/ui/dist at compile time and that directory is a
+# build artifact, not tracked in git — so it has to be built here, exactly as
+# upstream's Dockerfile does, or the server ends up without its UI.
+
+FROM docker.io/node:${NODE_VERSION} AS web
+
+ARG VERSION
+
+WORKDIR /src
+RUN git clone --depth 1 --branch "${VERSION}" \
+    https://github.com/ggml-org/llama.cpp.git .
+
+WORKDIR /src/tools/ui
+RUN npm ci && LLAMA_BUILD_NUMBER="${VERSION#b}" npm run build
+
+# ── Build ─────────────────────────────────────────────────────────────
+
+FROM docker.io/ubuntu:${UBUNTU_VERSION} AS build
+
+ARG VERSION
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        git build-essential cmake wget xz-utils \
+        libssl-dev curl ca-certificates \
+        libxcb-xinput0 libxcb-xinerama0 libxcb-cursor-dev \
+        libvulkan-dev glslc spirv-headers \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+RUN git clone --depth 1 --branch "${VERSION}" \
+    https://github.com/ggml-org/llama.cpp.git .
+
+# --verbose so the build log records which hunks moved: these are out-of-tree
+# patches against a moving base, so applying with offsets is expected and fine.
+# A real conflict fails the build here rather than quietly shipping an
+# unpatched image that benchmarks as a null result.
+COPY patches/ /patches/
+RUN set -eux; \
+    for p in /patches/*.patch; do \
+        echo "=== applying $(basename "$p")"; \
+        git apply --verbose "$p"; \
+    done; \
+    git diff --stat | tee /patches-applied.txt
+
+COPY --from=web /src/tools/ui/dist tools/ui/dist
+
+RUN cmake -B build \
+        -DGGML_NATIVE=OFF \
+        -DGGML_VULKAN=ON \
+        -DLLAMA_BUILD_TESTS=OFF \
+        -DGGML_BACKEND_DL=ON \
+        -DGGML_CPU_ALL_VARIANTS=ON \
+    && cmake --build build --config Release -j"$(nproc)" \
+    && mkdir -p /out/lib \
+    && find build -name "*.so*" -exec cp -P {} /out/lib \; \
+    && cp build/bin/llama-server /out/llama-server \
+    && ls -la /out /out/lib
+
+# ── Graft onto the llama-swap image ai-box runs ───────────────────────
+
+FROM ${BASE_IMAGE}
+
+USER root
+
+# Fail loudly if the base ever stops using the /app layout the whole stack
+# assumes — llama-swap's model map and ai-bench both exec /app/llama-server.
+RUN test -f /app/llama-server && test -f /app/llama-swap \
+    || (echo "base image is not the expected /app layout" >&2; exit 1)
+
+COPY --from=build --chown=10001:10001 /out/lib/ /app/
+COPY --from=build --chown=10001:10001 /out/llama-server /app/llama-server
+COPY --from=build --chown=10001:10001 /patches-applied.txt /app/patches-applied.txt
+
+USER 10001:10001

--- a/apps/llama-swap-strix/README.md
+++ b/apps/llama-swap-strix/README.md
@@ -1,0 +1,77 @@
+# llama-swap-strix
+
+`llama-swap` with an out-of-tree llama.cpp patch for **Strix Halo / gfx1151**,
+built for exactly one machine: `ai-box` (Framework Desktop, Ryzen AI Max+ 395,
+122 GiB unified memory, Vulkan/RADV backend). It is not a general-purpose image.
+
+## What it carries
+
+**ggml-org/llama.cpp[#25494](https://github.com/ggml-org/llama.cpp/pull/25494)**
+— *"vulkan: dequant q8_0 KV once in coopmat1"*, open upstream as of 2026-08.
+The Vulkan coopmat1 flash-attention path dequantises the q8_0 KV cache once per
+workgroup (32×); the patch does it once into scratch, in per-head-contiguous
+form, so the memory-bound read at prefill is cheaper.
+
+That matters here because **every generative route on ai-box runs `kv: q8_0`
+with `-fa 1`**, which is precisely the configuration the patch targets. Author's
+measurements on a Qwen3-MoE-30B-A3B with q8_0 KV — essentially ai-box's `coder`
+route:
+
+| | pp512 @32k | pp512 @65k | tg32 @32k | tg32 @65k |
+|---|---|---|---|---|
+| stock | 200.2 t/s | 99.1 t/s | 36.71 | 26.27 |
+| patched | **282.0 t/s** | **166.2 t/s** | 36.73 | 27.50 |
+
+Greedy output is reported byte-identical; the cost is a scratch buffer that
+scales with KV size (~268 MB @128k), which is why the on-box A/B watches GTT
+peak and not only tokens/s.
+
+The PR's `tests/test-backend-ops.cpp` hunk is **not** vendored: it does not
+apply to b10331 (the surrounding flash-attention test block moved) and the image
+builds with `LLAMA_BUILD_TESTS=OFF`. Everything under `ggml/` — the actual
+runtime change — applies with offsets.
+
+## How it is built
+
+Two build stages reproduce upstream's own `.devops/vulkan.Dockerfile` (same
+Ubuntu base, package list and cmake flags, plus the web UI stage llama-server
+embeds at compile time), with `patches/*.patch` applied to the checked out
+release tag first. The final stage then **grafts** the result onto the stock
+llama-swap image ai-box already runs, replacing only `/app/llama-server` and the
+ggml backend shared objects.
+
+The graft is what makes this useful: llama-swap, the entrypoint, the runtime
+libraries and every path stay byte-identical to production, so benchmarking this
+image against `BASE_IMAGE` changes one variable.
+
+⚠ **`VERSION` and `BASE_IMAGE` move together or not at all.** `VERSION` is the
+llama.cpp release tag to compile; `BASE_IMAGE` must be the llama-swap image
+built from that same llama.cpp build. Bumping one alone silently turns the A/B
+into "patch + version bump vs stock" and the numbers stop meaning anything.
+Renovate is disabled for this app (see `.renovaterc.json5`) for that reason —
+updates here are manual and deliberate.
+
+⚠ The patched Vulkan code lives in `libggml-vulkan.so`, **not** in the
+`llama-server` binary. An image with only the binary replaced runs perfectly and
+benchmarks exactly like stock — which reads as "the patch does nothing" rather
+than as a build error. `container_test.go` asserts the libraries are there.
+
+## Using it
+
+Consumed by `ai-box` via `aibox_images.llama_swap_patched` (digest-pinned, in
+`k8s-home/ansible/group_vars/ai_box/main.yml` of the infra repo). It is wired in
+as an extra **benchmark backend** first, not as the serving image:
+
+```
+ai-bench sweep coder-fa-patch    # backend dim: vulkan vs vulkan-patched
+```
+
+Promote it to `aibox_images.llama_swap` only if it wins prompt processing at
+two or more depths, does not regress token generation, and leaves GTT headroom
+for the largest resident tier.
+
+## Retire it when the PR merges
+
+This image exists only because #25494 is unmerged. Once it lands in an upstream
+llama.cpp release, point ai-box back at the stock `mostlygeek/llama-swap` image
+and delete this app.

--- a/apps/llama-swap-strix/container_test.go
+++ b/apps/llama-swap-strix/container_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"testing"
+
+	helpers "github.com/home-operations/containers/tests"
+)
+
+func Test(t *testing.T) {
+	image := helpers.GetTestImage("ghcr.io/fastlorenzo/llama-swap-strix:rolling")
+
+	// The whole image is a graft: a patched llama-server plus the ggml backend
+	// shared objects, copied over the stock llama-swap image. The failure mode
+	// worth testing for is a PARTIAL graft — the patched Vulkan flash-attention
+	// code lives in libggml-vulkan.so, not in the binary, so an image with only
+	// the binary replaced boots fine, serves fine, and benchmarks exactly like
+	// stock. That is indistinguishable from "the patch did nothing" unless the
+	// libraries are checked to be present.
+	//
+	// The runner has no GPU, so nothing here exercises Vulkan; these assert the
+	// image is assembled correctly, and the on-box `ai-bench sweep
+	// coder-fa-patch` decides whether it is any good.
+	helpers.RequireCommandSucceeds(t, image, nil, "/bin/sh", "-c",
+		"ls -1 /app/libggml-vulkan.so* /app/libggml-base.so*")
+
+	// Written by the build stage from `git diff --stat` after applying
+	// patches/, so a non-empty file proves the patches actually landed rather
+	// than being skipped by a glob that matched nothing.
+	helpers.RequireCommandSucceeds(t, image, nil, "/bin/sh", "-c",
+		"test -s /app/patches-applied.txt && cat /app/patches-applied.txt")
+
+	// The base image must survive the graft: llama-swap orchestrates, and
+	// ai-box's llama-swap config execs /app/llama-server per route.
+	helpers.RequireFileExists(t, image, "/app/llama-swap")
+	helpers.RequireFileExists(t, image, "/app/llama-server")
+
+	helpers.RequireCommandSucceeds(t, image, nil, "/app/llama-server", "--version")
+}

--- a/apps/llama-swap-strix/docker-bake.hcl
+++ b/apps/llama-swap-strix/docker-bake.hcl
@@ -1,0 +1,63 @@
+target "docker-metadata-action" {}
+
+variable "APP" {
+  default = "llama-swap-strix"
+}
+
+// Upstream llama.cpp release tag to build, NOT a semver — llama.cpp tags are
+// bNNNNN. Deliberately carries no `// renovate:` annotation: it MUST move in
+// lockstep with BASE_IMAGE below (same llama.cpp build), and an independent
+// bump of either one turns the whole point of this image — a one-variable A/B
+// against stock — into a meaningless comparison. .renovaterc.json5 disables
+// this app for the same reason.
+variable "VERSION" {
+  default = "b10331"
+}
+
+// The stock llama-swap image the patch is grafted onto and compared against —
+// the digest that tag v248-vulkan-b10331 (VERSION above, b10331) currently
+// resolves to. Not a free choice: it must be the build named by VERSION. Bump
+// both together or not at all, and re-run `ai-bench sweep coder-fa-patch`.
+//
+// NOTE this is NOT the digest ai-box's group_vars pins for llama_swap
+// (sha256:f3f7d5ec...). That older digest was dropped from the registry
+// (mostlygeek re-pushed the tag) and no longer pulls — the box only still runs
+// it from local cache. For the A/B to stay one-variable, ai-box should re-pin
+// llama_swap to this same digest; see the PR discussion.
+variable "BASE_IMAGE" {
+  default = "ghcr.io/mostlygeek/llama-swap@sha256:23b44d01e07a3c0c0c2dc270a9faac21b666d7e99324c5190982f5d504008d80"
+}
+
+variable "SOURCE" {
+  default = "https://github.com/ggml-org/llama.cpp"
+}
+
+group "default" {
+  targets = ["image-local"]
+}
+
+target "image" {
+  inherits = ["docker-metadata-action"]
+  args = {
+    VERSION    = "${VERSION}"
+    BASE_IMAGE = "${BASE_IMAGE}"
+  }
+  labels = {
+    "org.opencontainers.image.source" = "${SOURCE}"
+  }
+}
+
+target "image-local" {
+  inherits = ["image"]
+  output = ["type=docker"]
+  tags = ["${APP}:${VERSION}"]
+}
+
+// amd64 only: this exists for one gfx1151 APU. An arm64 build would be a long
+// Vulkan compile producing an image nothing will ever pull.
+target "image-all" {
+  inherits = ["image"]
+  platforms = [
+    "linux/amd64"
+  ]
+}

--- a/apps/llama-swap-strix/patches/25494-vulkan-coopmat1-q8_0-kv-dequant.patch
+++ b/apps/llama-swap-strix/patches/25494-vulkan-coopmat1-q8_0-kv-dequant.patch
@@ -1,0 +1,168 @@
+diff --git a/ggml/src/ggml-vulkan/ggml-vulkan.cpp b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+index a483d22c1a26..107412f062ea 100644
+--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
++++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+@@ -790,6 +790,7 @@ struct vk_device_struct {
+     vk_pipeline pipeline_quantize_q8_1_x4;
+ 
+     vk_pipeline pipeline_dequant[GGML_TYPE_COUNT];
++    vk_pipeline pipeline_dequant_transpose[GGML_TYPE_COUNT]; // fused dequant+transpose for FA quant-KV
+     vk_pipeline pipeline_dequant_mul_mat_vec_f32_f32[DMMV_WG_SIZE_COUNT][GGML_TYPE_COUNT][mul_mat_vec_max_cols];
+     vk_pipeline pipeline_dequant_mul_mat_vec_f16_f32[DMMV_WG_SIZE_COUNT][GGML_TYPE_COUNT][mul_mat_vec_max_cols];
+     vk_pipeline pipeline_dequant_mul_mat_vec_id_f32[DMMV_WG_SIZE_COUNT][GGML_TYPE_COUNT];
+@@ -5000,6 +5001,7 @@ static void ggml_vk_load_shaders(vk_device& device, vk_pipeline requested) {
+     ggml_vk_create_pipeline(device, device->pipeline_dequant[GGML_TYPE_Q5_0], "dequant_q5_0", dequant_q5_0_len, dequant_q5_0_data, "main", 2, 5 * sizeof(uint32_t), {256 * 16, 1, 1}, {}, 1);
+     ggml_vk_create_pipeline(device, device->pipeline_dequant[GGML_TYPE_Q5_1], "dequant_q5_1", dequant_q5_1_len, dequant_q5_1_data, "main", 2, 5 * sizeof(uint32_t), {256 * 16, 1, 1}, {}, 1);
+     ggml_vk_create_pipeline(device, device->pipeline_dequant[GGML_TYPE_Q8_0], "dequant_q8_0", dequant_q8_0_len, dequant_q8_0_data, "main", 2, 5 * sizeof(uint32_t), {256 * 16, 1, 1}, {}, 1);
++    ggml_vk_create_pipeline(device, device->pipeline_dequant_transpose[GGML_TYPE_Q8_0], "dequant_q8_0_transpose", dequant_q8_0_transpose_len, dequant_q8_0_transpose_data, "main", 2, 5 * sizeof(uint32_t), {256 * 16, 1, 1}, {}, 1);
+     ggml_vk_create_pipeline(device, device->pipeline_dequant[GGML_TYPE_Q2_K], "dequant_q2_k", dequant_q2_k_len, dequant_q2_k_data, "main", 2, 5 * sizeof(uint32_t), {256 * 64, 1, 1}, {}, 1);
+     ggml_vk_create_pipeline(device, device->pipeline_dequant[GGML_TYPE_Q3_K], "dequant_q3_k", dequant_q3_k_len, dequant_q3_k_data, "main", 2, 5 * sizeof(uint32_t), {256 * 64, 1, 1}, {}, 1);
+     ggml_vk_create_pipeline(device, device->pipeline_dequant[GGML_TYPE_Q4_K], "dequant_q4_k", dequant_q4_k_len, dequant_q4_k_data, "main", 2, 5 * sizeof(uint32_t), {256 * 32, 1, 1}, {}, 1);
+@@ -10258,9 +10260,25 @@ static void ggml_vk_flash_attn(ggml_backend_vk_context * ctx, vk_context& subctx
+ 
+     const bool f32acc = !ctx->device->fp16 || dst->op_params[3] == GGML_PREC_F32 || k->type == GGML_TYPE_BF16;
+ 
++    // dequant K/V once into an f16 scratch, reordered KV layout so FA can read without a stride
++    const bool k_quant = k->type != GGML_TYPE_F16 && k->type != GGML_TYPE_BF16 && k->type != GGML_TYPE_F32;
++    const bool v_quant = v->type != GGML_TYPE_F16 && v->type != GGML_TYPE_BF16 && v->type != GGML_TYPE_F32;
++    const bool use_dequant_kv = k_quant && v_quant && neq1 >= 64 &&
++                                k->nb[0] == ggml_type_size(k->type) && v->nb[0] == ggml_type_size(v->type) &&
++                                k->nb[1] >= k->nb[2] && v->nb[1] >= v->nb[2] &&
++                                ggml_is_contiguously_allocated(k) && ggml_is_contiguously_allocated(v) &&
++                                (uint64_t)ggml_nelements(k) * sizeof(ggml_fp16_t) <= ctx->device->properties.limits.maxStorageBufferRange &&
++                                (uint64_t)ggml_nelements(v) * sizeof(ggml_fp16_t) <= ctx->device->properties.limits.maxStorageBufferRange &&
++                                ctx->device->pipeline_dequant_transpose[k->type] != nullptr &&
++                                ctx->device->pipeline_dequant_transpose[v->type] != nullptr &&
++                                // coopmat2 already decodes quant K/V during the matrix load, so the f16 scratch is pure overhead there
++                                !ctx->device->coopmat2;
++    const ggml_type k_type_eff = use_dequant_kv ? GGML_TYPE_F16 : k->type;
++    const ggml_type v_type_eff = use_dequant_kv ? GGML_TYPE_F16 : v->type;
++
+     // For scalar/coopmat1 FA, we can use the "large" size to accommodate qga.
+     // For coopmat2 FA, we always use the small size (which is still pretty large for gqa).
+-    vk_fa_tuning_params tuning_params = get_fa_tuning_params(ctx->device, HSK, HSV, 512, KV, k->type, v->type, f32acc);
++    vk_fa_tuning_params tuning_params = get_fa_tuning_params(ctx->device, HSK, HSV, 512, KV, k_type_eff, v_type_eff, f32acc);
+     const uint32_t max_gqa = std::min(tuning_params.block_rows, 32u);
+ 
+     if (N <= 8 && qk_ratio > 1 && qk_ratio <= max_gqa &&
+@@ -10273,7 +10291,7 @@ static void ggml_vk_flash_attn(ggml_backend_vk_context * ctx, vk_context& subctx
+         workgroups_y /= gqa_ratio;
+     }
+ 
+-    tuning_params = get_fa_tuning_params(ctx->device, HSK, HSV, N, KV, k->type, v->type, f32acc);
++    tuning_params = get_fa_tuning_params(ctx->device, HSK, HSV, N, KV, k_type_eff, v_type_eff, f32acc);
+ 
+     const uint32_t q_stride = (uint32_t)(nbq1 / ggml_type_size(q->type));
+     uint32_t k_stride = (uint32_t)(nbk1 / ggml_type_size(k->type));
+@@ -10287,6 +10305,17 @@ static void ggml_vk_flash_attn(ggml_backend_vk_context * ctx, vk_context& subctx
+         v_stride /= 4;
+     }
+ 
++    uint32_t nbk2_eff = (uint32_t)nbk2, nbk3_eff = (uint32_t)nbk3;
++    uint32_t nbv2_eff = (uint32_t)nbv2, nbv3_eff = (uint32_t)nbv3;
++    if (use_dequant_kv) {
++        k_stride = HSK;
++        v_stride = HSV;
++        nbk2_eff = (uint32_t)((uint64_t)HSK * KV * sizeof(ggml_fp16_t));
++        nbk3_eff = (uint32_t)((uint64_t)HSK * KV * nek2 * sizeof(ggml_fp16_t));
++        nbv2_eff = (uint32_t)((uint64_t)HSV * KV * sizeof(ggml_fp16_t));
++        nbv3_eff = (uint32_t)((uint64_t)HSV * KV * nev2 * sizeof(ggml_fp16_t));
++    }
++
+     const uint32_t alignment = tuning_params.block_cols;
+     bool aligned = (KV % alignment) == 0 &&
+                    // the "aligned" shader variant will forcibly align strides, for performance
+@@ -10313,7 +10342,7 @@ static void ggml_vk_flash_attn(ggml_backend_vk_context * ctx, vk_context& subctx
+     bool use_mask_opt = mask && nem1 >= 32 && nem0 * nem1 > 32768 && nem0 >= tuning_params.block_cols * 16
+                         && (ctx->device->architecture != vk_device_architecture::AMD_GCN || HSK > 256 || HSV > 256);
+     vk_fa_pipeline_state fa_pipeline_state = get_fa_pipeline_state(ctx->device, tuning_params, HSK, HSV, aligned, f32acc,
+-                                                                   mask != nullptr, use_mask_opt, logit_softcap != 0, k->type, v->type);
++                                                                   mask != nullptr, use_mask_opt, logit_softcap != 0, k_type_eff, v_type_eff);
+ 
+     vk_pipeline pipeline = nullptr;
+ 
+@@ -10417,6 +10446,35 @@ static void ggml_vk_flash_attn(ggml_backend_vk_context * ctx, vk_context& subctx
+     vk_subbuffer sinks_buf = sinks ? ggml_vk_tensor_subbuffer(ctx, sinks) : q_buf;
+     vk_subbuffer mask_opt_buf = use_mask_opt ? ggml_vk_subbuffer(ctx, ctx->prealloc_y, 0) : q_buf;
+ 
++    if (use_dequant_kv) {
++        const uint64_t fp = sizeof(ggml_fp16_t);
++        const uint64_t k_f16_sz = (uint64_t)ggml_nelements(k) * fp;
++        const uint64_t v_f16_sz = (uint64_t)ggml_nelements(v) * fp;
++        if (ctx->prealloc_size_x < k_f16_sz + v_f16_sz) {
++            ctx->prealloc_size_x = k_f16_sz + v_f16_sz;
++            ggml_vk_preallocate_buffers(ctx, subctx);
++        }
++        vk_pipeline tr_k = ctx->device->pipeline_dequant_transpose[k->type];
++        vk_pipeline tr_v = ctx->device->pipeline_dequant_transpose[v->type];
++        ggml_pipeline_request_descriptor_sets(ctx, tr_k, 1);
++        ggml_pipeline_request_descriptor_sets(ctx, tr_v, 1);
++        if (ctx->prealloc_x_need_sync) {
++            ggml_vk_sync_buffers(ctx, subctx);
++        }
++        vk_subbuffer k_dst = vk_subbuffer{ ctx->prealloc_x, 0,        k_f16_sz };
++        vk_subbuffer v_dst = vk_subbuffer{ ctx->prealloc_x, k_f16_sz, v_f16_sz };
++        const uint32_t k_nel = (uint32_t)ggml_nelements(k);
++        const uint32_t v_nel = (uint32_t)ggml_nelements(v);
++        { const std::vector<uint32_t> pc = { (uint32_t)HSK, (uint32_t)nek2, (uint32_t)KV, 0, k_nel };
++          ggml_vk_dispatch_pipeline(ctx, subctx, tr_k, { k_buf, k_dst }, pc, { k_nel, 1, 1 }); }
++        { const std::vector<uint32_t> pc = { (uint32_t)HSV, (uint32_t)nev2, (uint32_t)KV, 0, v_nel };
++          ggml_vk_dispatch_pipeline(ctx, subctx, tr_v, { v_buf, v_dst }, pc, { v_nel, 1, 1 }); }
++        ggml_vk_sync_buffers(ctx, subctx);
++        ctx->prealloc_x_need_sync = true;
++        k_buf = k_dst;
++        v_buf = v_dst;
++    }
++
+     uint32_t mask_n_head_log2 = ((sinks != nullptr) << 24) | n_head_log2;
+ 
+     if (use_mask_opt)
+@@ -10446,8 +10504,8 @@ static void ggml_vk_flash_attn(ggml_backend_vk_context * ctx, vk_context& subctx
+                                               (uint32_t)nev2, (uint32_t)nev3,
+                                               nem1, nem2, nem3,
+                                               q_stride, (uint32_t)nbq2, (uint32_t)nbq3,
+-                                              k_stride, (uint32_t)nbk2, (uint32_t)nbk3,
+-                                              v_stride, (uint32_t)nbv2, (uint32_t)nbv3,
++                                              k_stride, nbk2_eff, nbk3_eff,
++                                              v_stride, nbv2_eff, nbv3_eff,
+                                               scale, max_bias, logit_softcap,
+                                               mask_n_head_log2, m0, m1,
+                                               gqa_ratio, split_kv, split_k };
+diff --git a/ggml/src/ggml-vulkan/vulkan-shaders/dequant_q8_0.comp b/ggml/src/ggml-vulkan/vulkan-shaders/dequant_q8_0.comp
+index 10844ddf7813..3b3fbbe8999d 100644
+--- a/ggml/src/ggml-vulkan/vulkan-shaders/dequant_q8_0.comp
++++ b/ggml/src/ggml-vulkan/vulkan-shaders/dequant_q8_0.comp
+@@ -18,7 +18,18 @@ void main() {
+         return;
+     }
+ 
++#ifdef DEQUANT_TRANSPOSE
++    // read [HS, NH, KV, NS], write [HS, KV, NH, NS]
++    const uint HS = p.M, NH = p.K, KVn = p.stride_a;
++    const uint e0 = ib * 32;
++    const uint b_idx = (e0 % HS)
++                     + ((e0 / (HS * NH)) % KVn) * HS
++                     + ((e0 / HS) % NH) * (HS * KVn)
++                     + (e0 / (HS * NH * KVn)) * (HS * KVn * NH)
++                     + 16 * il;
++#else
+     const uint b_idx = 1024*i + 32*ir + 16*il;
++#endif
+ 
+     const float d = float(data_a[ib].d);
+ 
+diff --git a/ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp b/ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp
+index 1925582ffedb..ebc66c65da87 100644
+--- a/ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp
++++ b/ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp
+@@ -753,6 +753,10 @@ void process_shaders() {
+         if (tname != "f16" && tname != "bf16") {
+             string_to_spv("dequant_" + tname, "dequant_" + tname + ".comp", merge_maps(base_dict, {{data_a_key, "1"}, {"D_TYPE", "float16_t"}}));
+         }
++        // Fused dequant+transpose variant for FA quant-KV (per-head-contiguous f16 scratch).
++        if (tname == "q8_0") {
++            string_to_spv("dequant_" + tname + "_transpose", "dequant_" + tname + ".comp", merge_maps(base_dict, {{data_a_key, "1"}, {"D_TYPE", "float16_t"}, {"DEQUANT_TRANSPOSE", "1"}}));
++        }
+ 
+         shader = (tname == "f32" || tname == "f16" || tname == "bf16") ? "get_rows.comp" : "get_rows_quant.comp";
+ 


### PR DESCRIPTION
## What

New app `llama-swap-strix`: `llama-swap` carrying **ggml-org/llama.cpp[#25494](https://github.com/ggml-org/llama.cpp/pull/25494)** (unmerged) — dequant q8_0 KV once in the Vulkan coopmat1 flash-attention path instead of once per workgroup. That is the exact configuration every generative route on `ai-box` (Strix Halo / gfx1151) runs: `kv: q8_0` + `-fa 1`.

Author-reported on a Qwen3-MoE-30B-A3B with q8_0 KV (≈ ai-box's `coder` route):

| | pp512 @32k | pp512 @65k | tg32 @32k | tg32 @65k |
|---|---|---|---|---|
| stock | 200.2 t/s | 99.1 t/s | 36.71 | 26.27 |
| patched | **282.0** | **166.2** | 36.73 | 27.50 |

Greedy output byte-identical; cost is a scratch buffer that scales with KV size (~268 MB @128k).

## How

Two build stages reproduce upstream llama.cpp's own `.devops/vulkan.Dockerfile` (same base, packages, cmake flags, plus the embedded web UI), applying `patches/*.patch` to the checked-out release tag first, then **graft** the patched `llama-server` **and the ggml backend `.so`s** onto the stock `llama-swap` image ai-box already runs.

- The Vulkan FA code is in `libggml-vulkan.so`, **not** the binary — a binary-only copy would build, run, and benchmark as a null result. `container_test.go` asserts the libs are present and `patches-applied.txt` is non-empty.
- Grafting onto the same `BASE_IMAGE` keeps the eventual A/B (`ai-bench sweep coder-fa-patch` on ai-box) to one variable.
- The PR's `tests/test-backend-ops.cpp` hunk is dropped (doesn't apply to b10331; built with `LLAMA_BUILD_TESTS=OFF`).

## Notes for review

- **`VERSION` (llama.cpp tag) and `BASE_IMAGE` (the llama-swap build from that same tag) must move together.** Renovate is disabled for this app in `.renovaterc.json5` so a bot can't bump one alone and silently invalidate every benchmark.
- **amd64 only** — this exists for one gfx1151 APU.
- **Temporary:** delete this app when #25494 merges upstream.

Local checks: `hadolint` clean, `go vet ./apps/llama-swap-strix/...`, `docker buildx bake --print`. The image has **not** been built end-to-end yet — first CI build is the real test (npm ci for the web UI stage, and whether a full Vulkan compile fits the runner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)